### PR TITLE
prep v0.1.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digitalocean/dots",
-  "version": "1.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digitalocean/dots",
-      "version": "1.0.1",
+      "version":  "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/core-http": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digitalocean/dots",
   "type": "module",
-  "version": "1.0.1",
+  "version": "0.1.0",
   "description": "TypeScript client generator based on DigitalOcean's OpenAPI specification.",
   "main": "examples/index.js",
   "scripts": {


### PR DESCRIPTION
Wanted to move the release version back to 0.1.0 instead of 1.0.1