### PR TITLE
Bump Node.js version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-           node-version: "18"
-           caache: "npm"
+           node-version: "20"
+           cache: "npm"
       
       - name: Install dependencies
         run: make dev-dependencies
@@ -26,12 +26,17 @@ jobs:
         run: make lint
     
   test:
-    name: Test
+    name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
 
     needs: 
       - lint
-            
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22"]
+
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -39,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with: 
-          node-version: "18"
+          node-version: ${{ matrix.node-version }}
           cache: "npm"
         
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/typescript-client-gen.yml
+++ b/.github/workflows/typescript-client-gen.yml
@@ -58,9 +58,9 @@ jobs:
           GH_TOKEN: ${{secrets.WORKFLOW_TOKEN}}
       
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: "20"
 
       - name: Install Dependencies
         run: npm install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ DoTs is a generated client. This section will walk you through generating the cl
 
 ### Prerequisites
 
-* NodeJs version: >= 18 
+* NodeJs version: >= 20.10 
 * [npm](https://www.npmjs.com/): To manage TypeScript/JavaScript dependencies
 * [Kiota](https://github.com/microsoft/kiota): The tool that generates the client libraries for accessing RESTful web services.
 
@@ -68,7 +68,7 @@ DoTs is a generated client. This section will walk you through generating the cl
 We use `jest` to define and run the tests.
 
 **_Requirements_**
-- [NodeJS 18 or above](https://nodejs.org/en/)
+- [NodeJS 20.10 or above](https://nodejs.org/en/)
 - [TypeScript 5 or above](https://www.typescriptlang.org/)
 - [Jest 30 or above](https://www.npmjs.com/package/jest) 
 - A DigitalOcean account with an active subscription. Along with a DigitalOcean token with proper permissions to manage DigitalOcean resources (for integration testing).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Getting Started
 #### Prerequisites 
-- [NodeJS 18 or above](https://nodejs.org/en/)
+- [NodeJS 20.10 or above](https://nodejs.org/en/)
 - [TypeScript 5 or above](https://www.typescriptlang.org/)
 - A DigitalOcean account with an active subscription. Along with a DigitalOcean token with proper permissions to manage DigitalOcean resources.
 - `"type": "module"` in your package.json (for ES module support)

--- a/docs/media/CONTRIBUTING.md
+++ b/docs/media/CONTRIBUTING.md
@@ -12,7 +12,7 @@ DoTs is a generated client. This section will walk you through generating the cl
 
 ### Prerequisites
 
-* NodeJs version: >= 18 
+* NodeJs version: >= 20.10 
 * [npm](https://www.npmjs.com/): To manage TypeScript/JavaScript dependencies
 * [Kiota](https://github.com/microsoft/kiota): The tool that generates the client libraries for accessing RESTful web services.
 
@@ -68,7 +68,7 @@ DoTs is a generated client. This section will walk you through generating the cl
 We use `jest` to define and run the tests.
 
 **_Requirements_**
-- [NodeJS 18 or above](https://nodejs.org/en/)
+- [NodeJS 20.10 or above](https://nodejs.org/en/)
 - [TypeScript 5 or above](https://www.typescriptlang.org/)
 - [Jest 30 or above](https://www.npmjs.com/package/jest) 
 - A DigitalOcean account with an active subscription. Along with a DigitalOcean token with proper permissions to manage DigitalOcean resources (for integration testing).

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "author": "DigitalOcean",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20.10.0"
+  },
   "keywords": [
     "digitalocean",
     "typescript",

--- a/src/dots/DigitalOceanApiKeyAuthenticationProvider.js
+++ b/src/dots/DigitalOceanApiKeyAuthenticationProvider.js
@@ -1,5 +1,4 @@
-// @ts-expect-error: Importing JSON for dynamic version in User-Agent header
-import pkg from '../../package.json' assert { type: "json" };
+import pkg from '../../package.json' with { type: "json" };
 /** Authenticate a request by using an API Key */
 export class DigitalOceanApiKeyAuthenticationProvider {
     /**

--- a/src/dots/DigitalOceanApiKeyAuthenticationProvider.ts
+++ b/src/dots/DigitalOceanApiKeyAuthenticationProvider.ts
@@ -1,6 +1,5 @@
 import { AuthenticationProvider, RequestInformation } from "@microsoft/kiota-abstractions";
-// @ts-expect-error: Importing JSON for dynamic version in User-Agent header
-import pkg from '../../package.json' assert { type: "json" };
+import pkg from '../../package.json' with { type: "json" };
 
 /** Authenticate a request by using an API Key */
 export class DigitalOceanApiKeyAuthenticationProvider implements AuthenticationProvider {

--- a/tests/mocked/DigitalOceanApiKeyAuthenticationProvider.test.ts
+++ b/tests/mocked/DigitalOceanApiKeyAuthenticationProvider.test.ts
@@ -1,8 +1,7 @@
 
 import { DigitalOceanApiKeyAuthenticationProvider } from "../../src/dots/DigitalOceanApiKeyAuthenticationProvider.js";
 import { RequestInformation } from "@microsoft/kiota-abstractions";
-// @ts-expect-error: Importing JSON for dynamic version in test
-import pkg from '../../package.json' assert { type: "json" };
+import pkg from '../../package.json' with { type: "json" };
 
 describe("DigitalOceanApiKeyAuthenticationProvider", () => {
     it("should add the User-Agent header to every request", async () => {


### PR DESCRIPTION
fix: replace deprecated `assert` import attribute with `with` for Node 20.10+ support