### PR TITLE
dots release v1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digitalocean/dots",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digitalocean/dots",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/core-http": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digitalocean/dots",
   "type": "module",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "TypeScript client generator based on DigitalOcean's OpenAPI specification.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
==> Merged PRs since last release

- #154 - @digitalocean-engineering - [bot] Updated inference_bearer_auth: Re-Generated From digitalocean/openapi@ceb93ca
- #153 - @harshmaru7 - fix: post-gen patch for embeddings input serialization
- #151 - @digitalocean-engineering - [bot] Add model service api defs: Re-Generated From digitalocean/openapi@9485b4a