### PR TITLE
ci pipeline fix

### DIFF
--- a/.github/workflows/typescript-client-gen.yml
+++ b/.github/workflows/typescript-client-gen.yml
@@ -67,6 +67,8 @@ jobs:
 
 
       - uses: microsoft/setup-kiota@v0.5.0
+        with:
+          version: 1.31.1
 
       - name: Check Kiota version
         run: kiota --version


### PR DESCRIPTION
All new OpenAPI-bot PRs opened against [digitalocean/dots](https://github.com/digitalocean/dots) are failing the Test (Node 20) and Test (Node 22) checks in pr.yml, blocking every regen of the TypeScript client

fix- Pin Kiota CLI to 1.31.1 in client-gen workflow to unblock OpenAPI bot PRs